### PR TITLE
Change empty message to be more directive

### DIFF
--- a/src/metamath/ui/MM_cmp_context_selector.res
+++ b/src/metamath/ui/MM_cmp_context_selector.res
@@ -96,7 +96,7 @@ let getNameFromFileSrc = (src:option<mmFileSource>):option<string> => {
 
 let getSummary = st => {
     if (st.singleScopes->Js.Array2.length == 1 && st.singleScopes[0].fileSrc->Belt_Option.isNone) {
-        "Empty MM context is loaded."
+        "No Metamath database is loaded; please select a database to load."
     } else {
         let filesInfo = st.singleScopes->Js_array2.map(ss => {
             let name = getNameFromFileSrc(ss.fileSrc)->Belt_Option.getWithDefault("")


### PR DESCRIPTION
Currently the tool just says "Empty MM context is loaded" on start, which is *true* but doesn't a hint to a new user what to do next.

Since this is one of the *first* things a new user will see, I think it's important to give them more specific directions. In this case, tell them specifically to select a database to load. The tool isn't very useful without a database, so I think we can be prescriptive at this point. Anyone who can use this tool with an empty database is advanced enough to not need prompting :-).