### PR TITLE
Clarify what "changing statement type" does

### DIFF
--- a/src/metamath/ui/MM_cmp_user_stmt.res
+++ b/src/metamath/ui/MM_cmp_user_stmt.res
@@ -1014,7 +1014,7 @@ let make = React.memoCustomCompareProps( ({
                     leftClickHnd(actToggleInfoExpanded)(evt)
                 }}
                 style=ReactDOM.Style.make(~cursor="pointer", ~fontWeight="bold", ())
-                title="Alt+<left-click> to change statement type. Left-click to show/hide the justification for provable."
+                title="Alt+<left-click> to change statement type between P (provable) and H (hypothesis). Alt is sometimes labelled Opt. Left-click to show/hide the justification for provable."
             >
                 {React.string(typStr->Js_string2.toUpperCase)}
             </span>


### PR DESCRIPTION
Currently the tooltip text says Alt+<left click> "changes the statement type" but that is too vague - what is meant by statement type? What are the options?

This commit modifies the text to make it clear that the two options are P (provable) and H (hypothesis).