### PR TITLE
Change "statement" to "step" in UI

### DIFF
--- a/src/metamath/ui/MM_cmp_editor.res
+++ b/src/metamath/ui/MM_cmp_editor.res
@@ -1104,36 +1104,36 @@ let make = (
                 }
                 />
                 {rndIconButton(~icon=<MM_Icons.ArrowDownward/>, ~onClick=actMoveCheckedStmtsDown, ~active= !editIsActive && canMoveCheckedStmts(state,false),
-                    ~title="Move selected statements down", ~smallBtns, ())}
+                    ~title="Move selected steps down", ~smallBtns, ())}
                 {rndIconButton(~icon=<MM_Icons.ArrowUpward/>, ~onClick=actMoveCheckedStmtsUp, ~active= !editIsActive && canMoveCheckedStmts(state,true),
-                    ~title="Move selected statements up", ~smallBtns, ())}
+                    ~title="Move selected steps up", ~smallBtns, ())}
                 {rndIconButton(~icon=<MM_Icons.Add/>, ~onClick=actAddNewStmt, ~active= !editIsActive,
-                    ~title="Add new statement (and place before selected statements if any)", ~smallBtns, ())}
+                    ~title="Add new step (and place before selected steps if any)", ~smallBtns, ())}
                 {rndIconButton(~icon=<MM_Icons.DeleteForever/>, ~onClick=actDeleteCheckedStmts,
-                    ~active= !editIsActive && atLeastOneStmtIsChecked, ~title="Delete selected statements", ~smallBtns, ()
+                    ~active= !editIsActive && atLeastOneStmtIsChecked, ~title="Delete selected steps", ~smallBtns, ()
                 )}
                 {rndIconButton(~icon=<MM_Icons.ControlPointDuplicate/>, ~onClick=actDuplicateStmt, 
-                    ~active= !editIsActive && isSingleStmtChecked(state), ~title="Duplicate selected statement", 
+                    ~active= !editIsActive && isSingleStmtChecked(state), ~title="Duplicate selected step", 
                     ~smallBtns, ())}
                 {rndIconButton(~icon=<MM_Icons.MergeType style=ReactDOM.Style.make(~transform="rotate(180deg)", ())/>, 
                     ~onClick=actMergeTwoStmts,
-                    ~active=oneStatementIsChecked, ~title="Merge two similar statements", ~smallBtns, ())}
+                    ~active=oneStatementIsChecked, ~title="Merge two similar steps", ~smallBtns, ())}
                 { 
                     rndIconButton(~icon=<MM_Icons.Search/>, ~onClick=actSearchAsrt,
                         ~active=generalModificationActionIsEnabled && state.frms->Belt_MapString.size > 0,
-                        ~title="Add new statements from existing assertions (and place before selected statements if any)", 
+                        ~title="Add new steps from existing assertions (and place before selected steps if any)", 
                         ~smallBtns, ()
                     ) 
                 }
                 { rndIconButton(~icon=<MM_Icons.TextRotationNone/>, ~onClick=actSubstitute, 
                     ~active=generalModificationActionIsEnabled && state.checkedStmtIds->Js.Array2.length <= 2,
-                    ~title="Apply a substitution to all statements", ~smallBtns,() ) }
+                    ~title="Apply a substitution to all steps", ~smallBtns,() ) }
                 { 
                     rndIconButton(~icon=<MM_Icons.Hub/>, ~onClick={() => actUnify(())},
                         ~active=generalModificationActionIsEnabled 
                                     && (!atLeastOneStmtIsChecked || singleProvableChecked->Belt.Option.isSome)
                                     && state.stmts->Js_array2.length > 0, 
-                        ~title="Unify all statements or unify selected provable bottom-up", ~smallBtns, () )
+                        ~title="Unify all steps or unify selected provable bottom-up", ~smallBtns, () )
                 }
                 { 
                     rndIconButton(~icon=<MM_Icons.Menu/>, ~onClick=actOpenMainMenu, ~active={!editIsActive}, 

--- a/src/metamath/ui/MM_cmp_save_or_discard.res
+++ b/src/metamath/ui/MM_cmp_save_or_discard.res
@@ -24,7 +24,7 @@ let make = (
                             <Button onClick={_=>onDiscard()}>
                                 {React.string(
                                     if (removeStmt) {
-                                        "Discard, remove statement"
+                                        "Discard, remove step"
                                     } else {
                                         "Discard, use this \u2192"
                                     }

--- a/src/metamath/ui/MM_cmp_settings.res
+++ b/src/metamath/ui/MM_cmp_settings.res
@@ -945,7 +945,7 @@ let make = (
                     onChange=evt2bool(actInitStmtIsGoalChange)
                 />
             }
-            label="Mark initial statement as a goal"
+            label="Mark initial step as a goal"
         />
         <FormControlLabel
             control={
@@ -954,23 +954,23 @@ let make = (
                     onChange=evt2bool(actStickGoalToBottomChange)
                 />
             }
-            label="Stick the goal statement to the bottom"
+            label="Stick the goal step to the bottom"
         />
         <TextField 
             size=#small
             style=ReactDOM.Style.make(~width="200px", ())
-            label="Initial statement label" 
+            label="Initial step label" 
             value=state.defaultStmtLabel
             onChange=evt2str(actDefaultStmtLabelChange)
-            title="This text is used as a label for the initial statement. If empty - a label will be generated automatically."
+            title="This text is used as a label for the initial step. If empty - a label will be generated automatically."
         />
         <TextField 
             size=#small
             style=ReactDOM.Style.make(~width="200px", ())
-            label="Default statement type" 
+            label="Default step type" 
             value=state.defaultStmtType 
             onChange=evt2str(actDefaultStmtTypeChange)
-            title="This text is used as initial content for new statements"
+            title="This text is used as initial content for new steps"
         />
         <MM_cmp_edit_stmts_setting
             editStmtsByLeftClick=state.editStmtsByLeftClick

--- a/src/metamath/ui/MM_cmp_settings.res
+++ b/src/metamath/ui/MM_cmp_settings.res
@@ -967,10 +967,10 @@ let make = (
         <TextField 
             size=#small
             style=ReactDOM.Style.make(~width="200px", ())
-            label="Default step type" 
+            label="Default statement type" 
             value=state.defaultStmtType 
             onChange=evt2str(actDefaultStmtTypeChange)
-            title="This text is used as initial content for new steps"
+            title="This text is used as the initial statement type for new statements"
         />
         <MM_cmp_edit_stmts_setting
             editStmtsByLeftClick=state.editStmtsByLeftClick

--- a/src/metamath/ui/MM_cmp_unify_bottom_up.res
+++ b/src/metamath/ui/MM_cmp_unify_bottom_up.res
@@ -695,7 +695,7 @@ let make = (
                             label="Sort results by"
                             onChange=evt2str(str => actSortByChange(sortByFromStr(str)))
                         >
-                            <MenuItem value="UnprovedStmtsNum">{React.string("Number of unproved statements")}</MenuItem>
+                            <MenuItem value="UnprovedStmtsNum">{React.string("Number of unproved steps")}</MenuItem>
                             <MenuItem value="NumOfNewVars">{React.string("Number of new variables")}</MenuItem>
                             <MenuItem value="AsrtLabel">{React.string("Assertion label")}</MenuItem>
                         </Select>
@@ -770,7 +770,7 @@ let make = (
                                 onChange={_ => actToggleAllowNewStmts()}
                             />
                         }
-                        label="Allow new statements"
+                        label="Allow new steps"
                         style=ReactDOM.Style.make(
                             ~border="solid 1px lightgrey", 
                             ~borderRadius="7px", 
@@ -992,7 +992,7 @@ let make = (
                 {
                     rndRootStmtsForLevelShort(
                         ~title = "first level", 
-                        ~dialogTitle = "Select statements to derive from on level 0", 
+                        ~dialogTitle = "Select steps to derive from on level 0", 
                         ~getFlags = state => state.args0,
                         ~setFlags = newFlags => setState(updateArgs0(_, newFlags)),
                     )
@@ -1000,7 +1000,7 @@ let make = (
                 {
                     rndRootStmtsForLevelShort(
                         ~title = "other levels", 
-                        ~dialogTitle = "Select statements to derive from on other levels", 
+                        ~dialogTitle = "Select steps to derive from on other levels", 
                         ~getFlags = state => state.args1,
                         ~setFlags = newFlags => setState(updateArgs1(_, newFlags)),
                     )

--- a/src/metamath/ui/MM_cmp_user_stmt.res
+++ b/src/metamath/ui/MM_cmp_user_stmt.res
@@ -1055,10 +1055,10 @@ let make = React.memoCustomCompareProps( ({
             <ButtonGroup variant=#outlined size=#small >
                 <Button title="Expand selection" onClick={_=>actExpandSelection()} ?style> <MM_Icons.ZoomOutMap/> </Button>
                 <Button title="Shrink selection" onClick={_=>actShrinkSelection()} ?style> <MM_Icons.ZoomInMap/> </Button>
-                <Button title="Add new statement above" onClick={_=>actAddStmtAbove()} ?style> 
+                <Button title="Add new step above" onClick={_=>actAddStmtAbove()} ?style> 
                     <MM_Icons.Logout style=ReactDOM.Style.make(~transform="rotate(-90deg)", ()) />
                 </Button>
-                <Button title="Add new statement below" onClick={_=>actAddStmtBelow()} ?style> 
+                <Button title="Add new step below" onClick={_=>actAddStmtBelow()} ?style> 
                     <MM_Icons.Logout style=ReactDOM.Style.make(~transform="rotate(90deg)", ()) />
                 </Button>
                 <Button title="Copy to the clipboard" onClick={_=>actCopyToClipboard()} ?style> <MM_Icons.ContentCopy/> </Button>
@@ -1267,7 +1267,7 @@ let make = React.memoCustomCompareProps( ({
                     ()
                 )
                 title={
-                    chgTypShortcutName ++ " to change statement type between P (provable), G (goal) and H (hypothesis). " 
+                    chgTypShortcutName ++ " to change step type between P (provable), G (goal) and H (hypothesis). " 
                         ++ "Alt is sometimes labelled Opt. " 
                         ++ showJstfShortcutName ++ " to show/hide the justification for provable."
                 }
@@ -1430,7 +1430,7 @@ let make = React.memoCustomCompareProps( ({
         rndProofStatus(
             ~proofStatus=stmt.proofStatus, 
             ~readyTooltip="Proof is ready, left-click to generate compressed proof",
-            ~waitingTooltip="Justification for this statement is correct",
+            ~waitingTooltip="Justification for this step is correct",
             ~noJstfTooltip="Justification cannot be determined automatically. Click to debug.",
             ~jstfIsIncorrectTooltip="Justification is incorrect. Click to debug.",
             ~onReadyIconClicked=onGenerateProof,

--- a/src/metamath/worker/MM_wrk_editor.res
+++ b/src/metamath/worker/MM_wrk_editor.res
@@ -261,7 +261,7 @@ let editorGetStmtById = (st,id) => st.stmts->Js_array2.find(stmt => stmt.id == i
 
 let editorGetStmtByIdExn = (st:editorState,id:stmtId):userStmt => {
     switch editorGetStmtById(st,id) {
-        | None => raise(MmException({msg:`editorGetStmtByIdExn: Cannot find a step by step label.`}))
+        | None => raise(MmException({msg:`editorGetStmtByIdExn: Cannot find a step by id.`}))
         | Some(stmt) => stmt
     }
 }
@@ -986,13 +986,13 @@ let validateStmtExpr = (
             | Some(expr) => {
                 switch wrkCtx->getHypByExpr(expr) {
                     | Some(hyp) => {
-                        {...stmt, stmtErr:Some(`This step is the same as the previously defined` 
+                        {...stmt, stmtErr:Some(`This statement is the same as the previously defined` 
                             ++ ` hypothesis - '${hyp.label}'`)}
                     }
                     | _ => {
                         switch definedUserExprs->Belt_HashMap.get(expr) {
                             | Some(prevStmtLabel) => {
-                                {...stmt, stmtErr:Some(`This step is the same as the previous` 
+                                {...stmt, stmtErr:Some(`This statement is the same as the previous` 
                                     ++ ` one - '${prevStmtLabel}'`)}
                             }
                             | None => stmt
@@ -2075,10 +2075,10 @@ let replaceRef = (st,~replaceWhat,~replaceWith):result<editorState,string> => {
 
 let mergeStmts = (st:editorState,id1:string,id2:string):result<editorState,string> => {
     switch st->editorGetStmtById(id1) {
-        | None => Error(`Cannot find a step with label = '${id1}'`)
+        | None => Error(`Cannot find a step with id = '${id1}'`)
         | Some(stmt1) => {
             switch st->editorGetStmtById(id2) {
-                | None => Error(`Cannot find a step with label = '${id2}'`)
+                | None => Error(`Cannot find a step with id = '${id2}'`)
                 | Some(stmt2) => {
                     if (stmt1.cont->contToStr != stmt2.cont->contToStr) {
                         Error(`Steps to merge must have identical expressions.`)


### PR DESCRIPTION
We recently agreed that it'd be clearer in the UI if we said that there were many *steps*, and each step contained a *statement*. This commit modifies the UI to more consistently say "step" when step is what was intended. Renaming "statement" to "step" everywhere in the UI would be incorrect, as in many cases "statement" is intended. I also changed "id" to "label" in a few places, again, for consistency.

There are probably a few missed spots, which will have to be fixed by future commits, but this at least gets things started.

This does *not* try to rename anything in the code, just the UI.