### PR TITLE
Reduce left/right statement padding

### DIFF
--- a/src/metamath/ui/MM_cmp_user_stmt.res
+++ b/src/metamath/ui/MM_cmp_user_stmt.res
@@ -1181,7 +1181,7 @@ let make = React.memoCustomCompareProps( ({
             let elems = [
                 <Paper 
                     style=ReactDOM.Style.make(
-                        ~padding="1px 1px",
+                        ~padding="1px 3px",
                         ~backgroundColor=
                             if (stmt.stmtErr->Belt_Option.isSome || stmt.syntaxErr->Belt_Option.isSome) {
                                 "rgb(255,230,230)"

--- a/src/metamath/ui/MM_cmp_user_stmt.res
+++ b/src/metamath/ui/MM_cmp_user_stmt.res
@@ -1181,7 +1181,7 @@ let make = React.memoCustomCompareProps( ({
             let elems = [
                 <Paper 
                     style=ReactDOM.Style.make(
-                        ~padding="1px 10px", 
+                        ~padding="1px 1px",
                         ~backgroundColor=
                             if (stmt.stmtErr->Belt_Option.isSome || stmt.syntaxErr->Belt_Option.isSome) {
                                 "rgb(255,230,230)"


### PR DESCRIPTION
Reduce the left/right statement padding.
The longer padding makes it look there is an extra space on each end (even though there isn't). More importantly to me, the extra space can create unnecessary new lines on a smartphone when showing relatively simple expressions in the 2+2=4 proof.