### PR TITLE
Shorten context summary at top for smartphones

### DIFF
--- a/src/metamath/ui/MM_cmp_context_selector.res
+++ b/src/metamath/ui/MM_cmp_context_selector.res
@@ -111,12 +111,12 @@ let getSummary = st => {
             let name = getNameFromFileSrc(ss.fileSrc)->Belt_Option.getWithDefault("")
             let readInstr = switch ss.readInstr {
                 | ReadAll => ""
-                | StopBefore => `, stopped before '${ss.label->Belt_Option.getWithDefault("")}'`
-                | StopAfter => `, stopped after '${ss.label->Belt_Option.getWithDefault("")}'`
+                | StopBefore => `, before '${ss.label->Belt_Option.getWithDefault("")}'`
+                | StopAfter => `, after '${ss.label->Belt_Option.getWithDefault("")}'`
             }
             name ++ readInstr
         })
-        "Loaded: " ++ filesInfo->Js_array2.joinWith("; ")
+        "Loaded " ++ filesInfo->Js_array2.joinWith("; ")
     }
 }
 


### PR DESCRIPTION
The context summary at the top is too long for smartphones even when you're stopped just before theorems with short names like '2p2e4'.

This commit shortens the displayed text so that it provides the same information but with less text. It removes the ";" after "Loaded", and it removes the unnecessary word "stopped" (this was already shown when you selected it, and "before" and "after" already convey the same information).

The result is that on '2p2e4' and 'reccot' it only requires *one* line instead of two, so the user doesn't need to configure anything for it to take up less space. Smartphone displays are small, making display space a premium, and we especially don't want to distract people who are just starting to use the tool.