### PR TITLE
Rename icon "substitution" to "replacement" in UI. Fixes #75

### DIFF
--- a/src/metamath/ui/MM_cmp_editor.res
+++ b/src/metamath/ui/MM_cmp_editor.res
@@ -1127,7 +1127,7 @@ let make = (
                 }
                 { rndIconButton(~icon=<MM_Icons.TextRotationNone/>, ~onClick=actSubstitute, 
                     ~active=generalModificationActionIsEnabled && state.checkedStmtIds->Js.Array2.length <= 2,
-                    ~title="Apply a substitution to all steps", ~smallBtns,() ) }
+                    ~title="Apply a replacement to all steps", ~smallBtns,() ) }
                 { 
                     rndIconButton(~icon=<MM_Icons.Hub/>, ~onClick={() => actUnify(())},
                         ~active=generalModificationActionIsEnabled 

--- a/src/metamath/ui/MM_cmp_substitution.res
+++ b/src/metamath/ui/MM_cmp_substitution.res
@@ -201,7 +201,7 @@ let make = (
             {rndError(state.expr2Err)}
             <Row>
                 <Button onClick={_=>actDetermineSubs()} variant=#contained color="grey" >
-                    {React.string("Find substitution")}
+                    {React.string("Find replacement")}
                 </Button>
                 <Button onClick={_=>onCanceled()}> {React.string("Cancel")} </Button>
             </Row>
@@ -358,7 +358,7 @@ let make = (
                     <>
                         {
                             React.string(
-                                `Found substitutions: `
+                                `Found replacements: `
                                     ++ `${getNumberOfResults(state.results)->Belt_Int.toString} valid, `
                             )
                         }


### PR DESCRIPTION
The word "substitution" is confusing, because it has multiple meanings. Is it the fundamental Metamath operation? The "A with arrow" icon?

This commit changes the UI so that the "A with arrow" icon is *always* described as "replacement", never as "substitution". This action already used the term "replacement" in some places (e.g., "Replace with?"), but not in others.
Thus, it made sense to switch this icon so it consistently uses the term replacement.

This commit does *not* try to rename anything in the code itself. The user doesn't care what the code calls it. The code could be changed later to match this UI naming convention, but there's no urgent need to do that.