### PR TITLE
Clarify step type dropdown

### DIFF
--- a/src/metamath/ui/MM_cmp_user_stmt.res
+++ b/src/metamath/ui/MM_cmp_user_stmt.res
@@ -1338,6 +1338,10 @@ let make = React.memoCustomCompareProps( ({
 
     let rndTyp = () => {
         if (stmt.typEditMode) {
+            let typStrLowerCase = switch stmt.typ {
+                | E => "e"
+                | P => if (stmt.isGoal) {"g"} else {"p"}
+            }
             <FormControl 
                 size=#small 
                 style=ReactDOM.Style.make(
@@ -1347,12 +1351,12 @@ let make = React.memoCustomCompareProps( ({
                 )
             >
                 <Select
-                    value=""
+                    value={typStrLowerCase}
                     onChange=evt2str(actTypEditDone)
                 >
-                    <MenuItem value="e">{React.string("H")}</MenuItem>
-                    <MenuItem value="p">{React.string("P")}</MenuItem>
-                    <MenuItem value="g">{React.string("G")}</MenuItem>
+                    <MenuItem value="e">{React.string("H - (Essential) Hypothesis")}</MenuItem>
+                    <MenuItem value="p">{React.string("P - Provable Statement")}</MenuItem>
+                    <MenuItem value="g">{React.string("G - Goal Statement")}</MenuItem>
                 </Select>
             </FormControl>
         } else {

--- a/src/metamath/ui/MM_cmp_user_stmt.res
+++ b/src/metamath/ui/MM_cmp_user_stmt.res
@@ -937,6 +937,10 @@ let make = React.memoCustomCompareProps( ({
         let (newTyp,newIsGoal) = userStmtTypeAndIsGoalFromStr(newTypStr)
         onTypEditDone(newTyp,newIsGoal)
     }
+
+    let actTypEditCancel = () => {
+        onTypEditDone(stmt.typ, stmt.isGoal)
+    }
     
     let actContEditDone = () => {
         onContEditDone(state.newText->Js_string2.trim)
@@ -1342,23 +1346,30 @@ let make = React.memoCustomCompareProps( ({
                 | E => "e"
                 | P => if (stmt.isGoal) {"g"} else {"p"}
             }
-            <FormControl 
-                size=#small 
-                style=ReactDOM.Style.make(
-                    ~marginLeft=stmtPartMarginLeft, 
-                    ~marginTop=stmtPartMarginTop, 
-                    ()
-                )
-            >
-                <Select
-                    value={typStrLowerCase}
-                    onChange=evt2str(actTypEditDone)
+            <Col spacing=0.>
+                <FormControl
+                    size=#small
+                    style=ReactDOM.Style.make(
+                        ~marginLeft=stmtPartMarginLeft,
+                        ~marginTop=stmtPartMarginTop,
+                        ()
+                    )
                 >
-                    <MenuItem value="e">{React.string("H - (Essential) Hypothesis")}</MenuItem>
-                    <MenuItem value="p">{React.string("P - Provable Statement")}</MenuItem>
-                    <MenuItem value="g">{React.string("G - Goal Statement")}</MenuItem>
-                </Select>
-            </FormControl>
+                    <Select
+                        value={typStrLowerCase}
+                        onChange=evt2str(actTypEditDone)
+                    >
+                        <MenuItem value="e">{React.string("H - (Essential) Hypothesis")}</MenuItem>
+                        <MenuItem value="p">{React.string("P - Provable Statement")}</MenuItem>
+                        <MenuItem value="g">{React.string("G - Goal Statement")}</MenuItem>
+                    </Select>
+                </FormControl>
+                {
+                    rndIconButton(
+                        ~icon=<MM_Icons.CancelOutlined/>, ~onClick=actTypEditCancel, ~title="Cancel", ~color=None, ()
+                    )
+                }
+            </Col>
         } else {
             let typStr = switch stmt.typ {
                 | E => "H"


### PR DESCRIPTION
Up to this point the step type dropdown has only shown a single letter (P, H, and recently G).

This commit modifies the dropdown to give a slightly longer explanation of what each letter means
(if the user doesn't know or remember).
It also records the current state, so the current state is highlighted in the dropdown.
Hopefully this makes the UI just a little more discoverable and clearer to new users.