### PR TITLE
Eliminate the legacy ReactDOMRe

### DIFF
--- a/src/metamath/utils/Xml_to_React.res
+++ b/src/metamath/utils/Xml_to_React.res
@@ -94,16 +94,12 @@ let createStyle = (attrs:Belt_MapString.t<string>, ~addBorder:bool):option<React
 
 let createDomProps = (attrs:Belt_MapString.t<string>, ~addBorder:bool):option<ReactDOM.domProps> => {
     if (attrs->Belt_MapString.size != 0 || addBorder) {
-        let resultRef = ref({}:ReactDOM.domProps)
-        switch createStyle(attrs, ~addBorder) {
-            | None => ()
-            | Some(style) => resultRef.contents = {...resultRef.contents, style: style}
-        }
-        switch (attrs->Belt_MapString.get("href")) {
-            | None => ()
-            | Some(href) => resultRef.contents = {...resultRef.contents, href: href, title: href, target: "_blank"}
-        }
-        Some(resultRef.contents)
+        Some({
+            style:?createStyle(attrs, ~addBorder),
+            href:?(attrs->Belt_MapString.get("href")),
+            title:?(attrs->Belt_MapString.get("href")),
+            target:?(attrs->Belt_MapString.get("href")->Belt_Option.map(_ => "_blank")),
+        })
     } else {
         None
     }

--- a/src/metamath/utils/Xml_to_React.res
+++ b/src/metamath/utils/Xml_to_React.res
@@ -92,16 +92,18 @@ let createStyle = (attrs:Belt_MapString.t<string>, ~addBorder:bool):option<React
     }
 }
 
-let createDomProps = (attrs:Belt_MapString.t<string>, ~addBorder:bool):option<ReactDOMRe.domProps> => {
+let createDomProps = (attrs:Belt_MapString.t<string>, ~addBorder:bool):option<ReactDOM.domProps> => {
     if (attrs->Belt_MapString.size != 0 || addBorder) {
-        Some(ReactDOMRe.domProps(
-            ~style=?createStyle(attrs,~addBorder),
-            ~fontWeight=?(attrs->Belt_MapString.get("font-weight")),
-            ~href=?(attrs->Belt_MapString.get("href")),
-            ~title=?(attrs->Belt_MapString.get("href")),
-            ~target=?(attrs->Belt_MapString.get("href")->Belt_Option.map(_ => "_blank")),
-            ()
-        ))
+        let resultRef = ref({}:ReactDOM.domProps)
+        switch createStyle(attrs, ~addBorder) {
+            | None => ()
+            | Some(style) => resultRef.contents = {...resultRef.contents, style: style}
+        }
+        switch (attrs->Belt_MapString.get("href")) {
+            | None => ()
+            | Some(href) => resultRef.contents = {...resultRef.contents, href: href, title: href, target: "_blank"}
+        }
+        Some(resultRef.contents)
     } else {
         None
     }
@@ -162,7 +164,7 @@ let xmlToReactElem = (xml:Xml_parser.xmlNode):result<reElem,string> => {
                                         | None => []
                                         | Some((_,children)) => children
                                     }
-                                    Ok(ReactDOMRe.createDOMElementVariadic(
+                                    Ok(ReactDOM.createDOMElementVariadic(
                                         name, 
                                         ~props=?createDomProps(
                                             attrs,


### PR DESCRIPTION
Note that I could have used instead of Some(resultRef.contents):

`

    Some({
          style:?createStyle(attrs,~addBorder),
          href:?(attrs->Belt_MapString.get("href")),
          title:?(attrs->Belt_MapString.get("href")),
          target:?(attrs->Belt_MapString.get("href")->Belt_Option.map(_ => "_blank")),
    })
`

But, this adds all 4 fields to the record (which can be seen in the debugger) with optional fields having the value 'undefined'. The original method didn't have this problem since it used the legacy function ReactDOMRe.domProps.

The only way that I could duplicate the original was to use the spread "..." functionality.