### PR TITLE
166 Fix "dev version gives exlimivv as an option even though it's invalid"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5895,9 +5895,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001481",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz",
-      "integrity": "sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==",
+      "version": "1.0.30001546",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001546.tgz",
+      "integrity": "sha512-zvtSJwuQFpewSyRrI3AsftF6rM0X80mZkChIt1spBGEvRglCrjTniXvinc8JKRoqTwXAgvqTImaN9igfSMtUBw==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/metamath/mm-utils/MM_asrt_apply.res
+++ b/src/metamath/mm-utils/MM_asrt_apply.res
@@ -370,11 +370,7 @@ let checkDisj = (
 ):option<unifErr> => {
     verifyDisjoints(~frmDisj, ~subs, ~debugLevel, ~isDisjInCtx = (n,m) => {
         if (n <= maxCtxVar && m <= maxCtxVar) {
-            if (isDisjInCtx(n,m)) {
-                true
-            } else {
-                allowNewDisjForExistingVars
-            }
+            isDisjInCtx(n,m) || allowNewDisjForExistingVars
         } else {
             true
         }

--- a/src/metamath/mm-utils/MM_asrt_apply.res
+++ b/src/metamath/mm-utils/MM_asrt_apply.res
@@ -368,17 +368,17 @@ let checkDisj = (
     ~isDisjInCtx:(int,int)=>bool,
     ~debugLevel:int,
 ):option<unifErr> => {
-    if (allowNewDisjForExistingVars) {
-        None
-    } else {
-        verifyDisjoints(~frmDisj, ~subs, ~debugLevel, ~isDisjInCtx = (n,m) => {
-            if (n <= maxCtxVar && m <= maxCtxVar) {
-                isDisjInCtx(n,m)
-            } else {
+    verifyDisjoints(~frmDisj, ~subs, ~debugLevel, ~isDisjInCtx = (n,m) => {
+        if (n <= maxCtxVar && m <= maxCtxVar) {
+            if (isDisjInCtx(n,m)) {
                 true
+            } else {
+                allowNewDisjForExistingVars
             }
-        })
-    }
+        } else {
+            true
+        }
+    })
 }
 
 let iterateSubstitutionsForResult = (

--- a/src/metamath/test/MM_asrt_apply_test.res
+++ b/src/metamath/test/MM_asrt_apply_test.res
@@ -175,6 +175,8 @@ let testApplyAssertions = (
     ~additionalStatements:array<stmt>=[],
     ~statements:array<(string,string)>,
     ~frameFilter:frame=>bool=_=>true,
+    ~allowEmptyArgs:bool=true,
+    ~allowNewDisjForExistingVars:bool=false,
     ~result:option<string>=?,
     ~fileWithExpectedResult:string,
     ()
@@ -274,6 +276,8 @@ let testApplyAssertions = (
         ~statements = stmtsForAppl,
         ~parenCnt,
         ~frameFilter,
+        ~allowEmptyArgs,
+        ~allowNewDisjForExistingVars,
         ~result=?result->Belt_Option.map(str => str->getSpaceSeparatedValuesAsArray->ctxSymsToIntsExn(workCtx,_)),
         ~onMatchFound = res => {
             switch actualResults->Belt_MutableMapString.get(res.frame.label) {
@@ -383,6 +387,20 @@ describe("applyAssertions", _ => {
             ],
             ~result="|- ( 2 + 2 ) = 4",
             ~fileWithExpectedResult = "./src/metamath/test/resources/applyAssertions-test-data/correct-order-of-hyps-matching.txt",
+            ()
+        )
+    })
+    it("does not introduce broken disjoints", _ => {
+        //https://github.com/expln/metamath-lamp/issues/166#issuecomment-1751814880
+        testApplyAssertions(
+            ~mmFilePath = "./src/metamath/test/resources/applAsrt-no-broken-disjoints._mm",
+            ~statements = [
+                ("1", "|- ( x = y -> x = y )"),
+            ],
+            ~result="|- ( E. x E. y x = y -> x = y )",
+            ~allowEmptyArgs=false,
+            ~allowNewDisjForExistingVars=true,
+            ~fileWithExpectedResult = "./src/metamath/test/resources/applyAssertions-test-data/no-broken-disjoints.txt",
             ()
         )
     })

--- a/src/metamath/test/resources/applAsrt-no-broken-disjoints._mm
+++ b/src/metamath/test/resources/applAsrt-no-broken-disjoints._mm
@@ -1,0 +1,13 @@
+$c |- = + ( ) { } [ ] 1 2 4 setvar wff E. -> $.
+$v ph ps x y $.
+var1 $f wff ph $.
+var2 $f wff ps $.
+var3 $f setvar x $.
+var4 $f setvar y $.
+
+${
+    $d y ps $.
+    $d x ps $.
+   exlimivv.1 $e |- ( ph -> ps ) $.
+   exlimivv  $a |- ( E. x E. y ph -> ps ) $.
+$}


### PR DESCRIPTION
Fix "dev version gives exlimivv as an option even though it's invalid" from https://github.com/expln/metamath-lamp/issues/166#issuecomment-1751814880