### PR TITLE
Tweak transform displayName to use Unicode arrow

### DIFF
--- a/src/metamath/test/MM_wrk_frag_transform_test_int.res
+++ b/src/metamath/test/MM_wrk_frag_transform_test_int.res
@@ -77,10 +77,10 @@ let state = objToFragmentTransformState
 external fromState: fragmentTransformState => {..} = "%identity"
 
 describe("MM_wrk_editor integration tests: MM_wrk_frag_transform", _ => {
-    it("Insert: X => ( X + A )", _ => {
+    it("Insert: X ⇒  ( X + A )", _ => {
         setTestDataDir("MM_wrk_frag_transform")
         let editorState = createEditorState( ~mmFilePath=setMmPath, ~stopBefore="mathbox", ~debug, () )
-        let transformName = "Insert: X => ( X + A )"
+        let transformName = "Insert: X ⇒  ( X + A )"
         let prepareState = params => {
             st => state({
                 "selMatch":fromState(st)["selMatch"], 
@@ -200,10 +200,10 @@ describe("MM_wrk_editor integration tests: MM_wrk_frag_transform", _ => {
         )
     })
 
-    it("Elide: ( X + A ) => X", _ => {
+    it("Elide: ( X + A ) ⇒  X", _ => {
         setTestDataDir("MM_wrk_frag_transform")
         let editorState = createEditorState( ~mmFilePath=setMmPath, ~stopBefore="mathbox", ~debug, () )
-        let transformName = "Elide: ( X + A ) => X"
+        let transformName = "Elide: ( X + A ) ⇒  X"
         let prepareState = params => {
             st => state({
                 "selMatch":fromState(st)["selMatch"], 
@@ -346,10 +346,10 @@ describe("MM_wrk_editor integration tests: MM_wrk_frag_transform", _ => {
         )
     })
 
-    it("Swap: X = Y => Y = X", _ => {
+    it("Swap: X = Y ⇒  Y = X", _ => {
         setTestDataDir("MM_wrk_frag_transform")
         let editorState = createEditorState( ~mmFilePath=setMmPath, ~stopBefore="mathbox", ~debug, () )
-        let transformName = "Swap: X = Y => Y = X"
+        let transformName = "Swap: X = Y ⇒  Y = X"
 
         testTransform( ~editorState, ~transformName,
             ~selectedFragment = "x = y",
@@ -376,10 +376,10 @@ describe("MM_wrk_editor integration tests: MM_wrk_frag_transform", _ => {
         )
     })
 
-    it("Associate: ( A + B ) + C => A + ( B + C )", _ => {
+    it("Associate: ( A + B ) + C ⇒  A + ( B + C )", _ => {
         setTestDataDir("MM_wrk_frag_transform")
         let editorState = createEditorState( ~mmFilePath=setMmPath, ~stopBefore="mathbox", ~debug, () )
-        let transformName = "Associate: ( A + B ) + C => A + ( B + C )"
+        let transformName = "Associate: ( A + B ) + C ⇒  A + ( B + C )"
         let prepareState = params => {
             st => state({
                 "selMatch":fromState(st)["selMatch"], 

--- a/src/metamath/ui/MM_frag_transform_default_script.res
+++ b/src/metamath/ui/MM_frag_transform_default_script.res
@@ -144,7 +144,7 @@ const insertCanBeTwoSided = selection => findMatch(selection,insertSelPatterns) 
  * X => [ X + A ] : else
  */
 const trInsert = {
-    displayName: () => "Insert: X => ( X + A )",
+    displayName: () => "Insert: X ⇒  ( X + A )",
     canApply: () => true,
     createInitialState: ({selection}) => ({
         selMatch: findMatch(selection,insertSelPatterns),
@@ -235,7 +235,7 @@ const elideCanBeTwoSided = selection => findMatch(selection,elideSelPatterns) !=
  * X + A => [ X ] : else // test: class X + Y
  */
 const trElide = {
-    displayName: () => "Elide: ( X + A ) => X",
+    displayName: () => "Elide: ( X + A ) ⇒  X",
     canApply:({selection}) => findMatch(selection,[['', '', ''], ['', '', '', '', '']]) !== undefined,
     createInitialState: ({selection}) => ({
         selMatch: findMatch(selection,elideSelPatterns),
@@ -435,7 +435,7 @@ const swapSelPat2 = ['', '', '', '', '']
 const swapSelPatterns = [swapSelPat1, swapSelPat2]
 
 const trSwap = {
-    displayName: () => "Swap: X = Y => Y = X",
+    displayName: () => "Swap: X = Y ⇒  Y = X",
     canApply:({selection}) => findMatch(selection,swapSelPatterns) !== undefined,
     createInitialState: ({selection}) => ({
         selMatch: findMatch(selection,swapSelPatterns)
@@ -483,7 +483,7 @@ const assocSelPat5_5 = ['','','',['','','','',''],'']
 const assocSelPatterns = [assocSelPat355, assocSelPat555, assocSelPat35_, assocSelPat3_5, assocSelPat55_, assocSelPat5_5]
 
 const trAssoc = {
-    displayName: () => "Associate: ( A + B ) + C => A + ( B + C )",
+    displayName: () => "Associate: ( A + B ) + C ⇒  A + ( B + C )",
     canApply:({selection}) => findMatch(selection,assocSelPatterns) !== undefined,
     createInitialState: ({selection}) => ({
         selMatch: findMatch(selection,assocSelPatterns),
@@ -599,7 +599,7 @@ const allTransforms = [
     trInsert, trElide, trSwap, trAssoc, trReplace,
     // makeSimpleTransform({
     //     // isDebug:true,
-    //     displayName: 'X => X = X',
+    //     displayName: 'X ⇒  X = X',
     //     pattern: [],
     //     makeInitial: ([x]) => [[x, YELLOW]],
     //     makeResult:  ([x]) => [[x, YELLOW], '=', [x, YELLOW]],


### PR DESCRIPTION
Instead of `=>` use Unicode `⇒` (Rightwards Double Arrow) in the transform display name. This symbol is much more visually distinct from `=>` (making it easier to see)
and I think it looks a little nicer.